### PR TITLE
Fix mksnapshot invocation on Windows with newer Node.js

### DIFF
--- a/tools/create-v8-snapshot.js
+++ b/tools/create-v8-snapshot.js
@@ -33,7 +33,8 @@ async function main () {
       '.bin',
       'mksnapshot' + (process.platform === 'win32' ? '.cmd' : '')
     ),
-    [snapshotScriptPath, '--output_dir', outputBlobPath]
+    [snapshotScriptPath, '--output_dir', outputBlobPath],
+    { shell: process.platform === 'win32' }
   )
 }
 


### PR DESCRIPTION
Necessary to avoid the `EINVAL` error on Windows when using Node.js 18+.